### PR TITLE
Clean admin page output

### DIFF
--- a/src/Admin/Page_Controller.php
+++ b/src/Admin/Page_Controller.php
@@ -23,12 +23,13 @@ class Page_Controller {
         );
     }
 
+    /**
+     * Render the plugin's main admin page.
+     *
+     * Outputs the container element for the React UI.
+     */
     public function render_main_page() {
-        error_log('render_main_page fired');
-        echo '<div class="notice notice-success"><p>CALLBACK HIT!</p></div>';
-        echo '++++';
         echo '<div id="root"></div>';
-        echo '++++';
     }
 
     public function enqueue_scripts( $hook ) {


### PR DESCRIPTION
## Summary
- remove debugging output from the admin page controller
- document render_main_page()

## Testing
- `vendor/bin/phpunit` *(fails: Patchwork functions not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6871b6bb19cc832aa52258cf27bdb019