### PR TITLE
Update ScoreCalculator tests for new parameter

### DIFF
--- a/tests/Unit/ScoreCalculatorTest.php
+++ b/tests/Unit/ScoreCalculatorTest.php
@@ -10,24 +10,28 @@ class ScoreCalculatorTest extends TestCase {
     public function test_calculate_with_all_passed() {
         $calculator = new ScoreCalculator();
         $results = ['rule1' => true, 'rule2' => true, 'rule3' => true];
-        $this->assertEquals(100, $calculator->calculate($results));
+        $performance_score = 100;
+        $this->assertEquals(100, $calculator->calculate($results, $performance_score));
     }
 
     public function test_calculate_with_some_passed() {
         $calculator = new ScoreCalculator();
         $results = ['rule1' => true, 'rule2' => false, 'rule3' => true];
-        $this->assertEquals(66, $calculator->calculate($results));
+        $performance_score = 66;
+        $this->assertEquals(66, $calculator->calculate($results, $performance_score));
     }
 
     public function test_calculate_with_all_failed() {
         $calculator = new ScoreCalculator();
         $results = ['rule1' => false, 'rule2' => false, 'rule3' => false];
-        $this->assertEquals(0, $calculator->calculate($results));
+        $performance_score = 0;
+        $this->assertEquals(0, $calculator->calculate($results, $performance_score));
     }
 
     public function test_calculate_with_empty_results() {
         $calculator = new ScoreCalculator();
         $results = [];
-        $this->assertEquals(100, $calculator->calculate($results));
+        $performance_score = 100;
+        $this->assertEquals(100, $calculator->calculate($results, $performance_score));
     }
 }


### PR DESCRIPTION
## Summary
- refactor ScoreCalculatorTest to use a `$performance_score` variable when calling `ScoreCalculator::calculate`
- keep expectations unchanged

## Testing
- `vendor/bin/phpunit tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6871b6b9a3b8832ab598de00138fe84b